### PR TITLE
Migrate module from ServiceMeshExtension to WasmPlugin

### DIFF
--- a/lab2/ossm-extension-body.yaml
+++ b/lab2/ossm-extension-body.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   pluginConfig:
     secret-word: secret
-  url: oci://quay.io/acidonpe/ossm-example-body-extension:1.0.0
+  url: oci://quay.io/isanchez/ossm-example-body-extension:1.0.0
   priority: 100
   phase: STATS
   selector:

--- a/lab2/ossm-extension-body.yaml
+++ b/lab2/ossm-extension-body.yaml
@@ -1,13 +1,13 @@
-apiVersion: maistra.io/v1
-kind: ServiceMeshExtension
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
 metadata:
   name: ossm-example-body-extension
 spec:
-  config:
+  pluginConfig:
     secret-word: secret
-  image: quay.io/isanchez/ossm-example-body-extension:1.0.0
-  phase: PostAuthZ
+  url: oci://quay.io/acidonpe/ossm-example-body-extension:1.0.0
   priority: 100
-  workloadSelector:
-    labels:
+  phase: STATS
+  selector:
+    matchLabels:
       app: httpbin

--- a/lab2/ossm-extension-headers.yaml
+++ b/lab2/ossm-extension-headers.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   pluginConfig:
     my-key: my-wasm-value
-  url: oci://quay.io/acidonpe/ossm-example-headers-extension:1.0.0
+  url: oci://quay.io/isanchez/ossm-example-headers-extension:1.0.0
   priority: 100
   phase: STATS
   selector:

--- a/lab2/ossm-extension-headers.yaml
+++ b/lab2/ossm-extension-headers.yaml
@@ -1,13 +1,13 @@
-apiVersion: maistra.io/v1
-kind: ServiceMeshExtension
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
 metadata:
   name: ossm-example-headers-extension
 spec:
-  config:
+  pluginConfig:
     my-key: my-wasm-value
-  image: quay.io/isanchez/ossm-example-headers-extension:1.0.0
-  phase: PostAuthZ
+  url: oci://quay.io/acidonpe/ossm-example-headers-extension:1.0.0
   priority: 100
-  workloadSelector:
-    labels:
+  phase: STATS
+  selector:
+    matchLabels:
       app: httpbin


### PR DESCRIPTION
Hi Nacho,

This PR allows the use of WASM plugins from OSSM 2.23.

The procedure used to migrate this plugin was [this](https://docs.openshift.com/container-platform/4.13/service_mesh/v2x/ossm-extensions.html#ossm-extensions-migration-overview_ossm-extensions).

NOTE: It is important that you build & push the new images to your quay registry or, alternatively, use my quay repository (quay.io/acidonpe) where you can find the new WASM plugins renamed.

Regards!